### PR TITLE
chore.: Update singularity definition to use `fslinstaller.py.mgb`

### DIFF
--- a/Singularity.pnlpipe
+++ b/Singularity.pnlpipe
@@ -12,6 +12,8 @@ From: redhat/ubi9:9.5-1738643550
 %files
 
     bin/* /usr/bin/
+    fslinstaller.py.mgb /home/pnlbwh/fslinstaller.py
+    .condarc /home/pnlbwh/.condarc
 
 %post
     #
@@ -112,18 +114,17 @@ From: redhat/ubi9:9.5-1738643550
     pip install .
     pip install plumbum
     conda deactivate
+    cd
     #
     # avoid git dubious ownership error
     git config --system --add safe.directory '*'
     #
     # install FSL
-    echo "Downloading FSL installer"
-    wget https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py -O fslinstaller.py > /dev/null 2>&1
-    echo "Installing FSL"
+    echo "Using MGB Compatible FSL installer"
     V=6.0.7
-    python fslinstaller.py -V $V -d $HOME/fsl-$V > /dev/null
+    python fslinstaller.py -V 6.0.7.18 -d $HOME/fsl-$V --miniconda Miniconda3-latest-Linux-x86_64.sh --cuda none --skip_ssl_verify --no_env > /dev/null
     cd $HOME/fsl-$V/share/fsl/bin
-    ln -s eddy_cuda10.2 eddy_cuda
+    ln -s eddy_cuda11.0 eddy_cuda
     cd
     # setup FSL environment
     export FSLDIR=$HOME/fsl-$V

--- a/Singularity.pnlpipe
+++ b/Singularity.pnlpipe
@@ -18,7 +18,7 @@ From: redhat/ubi9:9.5-1738643550
 %post
     #
     # set up user and working directory
-    mkdir /home/pnlbwh
+    mkdir -p /home/pnlbwh
     cd /home/pnlbwh
     export HOME=`pwd`
     #


### PR DESCRIPTION
This PR is the Singularity equivalent of the following commit: https://github.com/pnlbwh/pnlpipe-containers/commit/d74cc2d91cf9edc7bb9e262e3c94c652da29eaaa

Redid updates needed to bypass anaconada for singularity builds:
* copy .condarc with ssl_verify and channel_alias
* copy fslinstaller.py.mgb
* modify fslinstaller.py arguments
* update eddy_cuda symlink